### PR TITLE
solc: update math and fees libraries to allow ^0.8.21 version range

### DIFF
--- a/src/modules/fees/ManagementFeesLib.sol
+++ b/src/modules/fees/ManagementFeesLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import "src/utils/LogExpMathv08.sol";
 import "src/utils/Math.sol";

--- a/src/modules/fees/PerformanceFeesLib.sol
+++ b/src/modules/fees/PerformanceFeesLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 import { Math } from "src/utils/Math.sol";
 

--- a/src/utils/Math.sol
+++ b/src/utils/Math.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.21;
+pragma solidity ^0.8.21;
 
 library Math {
     /**


### PR DESCRIPTION
Allows to import easily libraries in other projects